### PR TITLE
Updated Record names to use CamelCase 

### DIFF
--- a/battleship/board/src/main.leo
+++ b/battleship/board/src/main.leo
@@ -6,7 +6,7 @@ program board.aleo {
     // 00100000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
     // A second u64 is needed to represent which squares have been played, with 1s being played squares and 0s being
     // unplayed squares.
-    record board_state {
+    record BoardState {
         owner: address,
         // The hits and misses registered on the opponent's board.
         hits_and_misses: u64,
@@ -23,8 +23,8 @@ program board.aleo {
     transition new_board_state(
         ships: u64,
         opponent: address,
-    ) -> board_state {
-        return board_state {
+    ) -> BoardState {
+        return BoardState {
             owner: self.caller,
             hits_and_misses: 0u64,
             played_tiles: 0u64,
@@ -39,12 +39,12 @@ program board.aleo {
     // Fails if this board has been started before.
     transition start_board(
         // The record of the board to start. A board can only be started once.
-        board: board_state,
-    ) -> board_state {
+        board: BoardState,
+    ) -> BoardState {
         // Ensure this board hasn't been used to start a game before.
         assert(!board.game_started);
 
-        return board_state {
+        return BoardState {
             owner: board.owner,
             hits_and_misses: board.hits_and_misses,
             played_tiles: board.played_tiles,
@@ -59,10 +59,10 @@ program board.aleo {
     // Fails if r1 has been played before.
     transition update_played_tiles(
         // The record of the board to update.
-        board: board_state,
+        board: BoardState,
         // The u64 equivalent of a bitstring fire coordinate to send to the opponent.
         shoot: u64,
-    ) -> board_state {
+    ) -> BoardState {
         // Need to make sure r1 is a valid move. Only one bit of r1 should be flipped.
         let flip_bit: u64 = shoot - 1u64;
         // bitwise and operation
@@ -76,7 +76,7 @@ program board.aleo {
         // Update played tiles.
         let played_tiles: u64 = board.played_tiles | shoot;
 
-        return board_state {
+        return BoardState {
             owner: board.owner,
             hits_and_misses: board.hits_and_misses,
             played_tiles,
@@ -90,14 +90,14 @@ program board.aleo {
     // Returns a new board state record that includes all the hits and misses.
     transition update_hits_and_misses(
         // The record of the board to update.
-        board: board_state,
+        board: BoardState,
         // The u64 equivalent of a bitstring of whether this player's previous move was a hit or miss.
         hit_or_miss: u64,
-    ) -> board_state {
+    ) -> BoardState {
         // Update hits and misses.
         let hits_and_misses: u64 = board.hits_and_misses | hit_or_miss;
 
-        return board_state {
+        return BoardState {
             owner: board.owner,
             hits_and_misses,
             played_tiles: board.played_tiles,

--- a/battleship/move/src/main.leo
+++ b/battleship/move/src/main.leo
@@ -1,5 +1,5 @@
 program move.aleo {
-    record move {
+    record Move {
         owner: address,
         incoming_fire_coordinate: u64,
         player_1: address,
@@ -11,17 +11,17 @@ program move.aleo {
     // Returns new move record owned by the opponent.
     transition create_move(
         // The move record created by the opponent.
-        move_record: move,
+        move_record: Move,
         // The u64 representation of incoming_fire_coordinate, the bitstring fire coordinate to send to the opponent.
         incoming_fire_coordinate: u64,
         // The u64 representation of prev_hit_or_miss, this player's previous fire coordinate as a hit or miss.
         prev_hit_or_miss: u64,
-    ) -> move {
+    ) -> Move {
         // A new move record should be created and owned by the opponent.
         let one_is_owner: bool = move_record.player_1 == move_record.owner;
         let opponent: address = one_is_owner ? move_record.player_2 : move_record.player_1;
 
-        return move {
+        return Move {
             owner: opponent,
             incoming_fire_coordinate,
             player_1: move_record.player_2,
@@ -32,8 +32,8 @@ program move.aleo {
 
     // Returns the move record owned by the opponent.
     // Note, this move record contains dummy fire coordinates and previous hit or miss.
-    transition start_game(player_2: address) -> move {
-        return move {
+    transition start_game(player_2: address) -> Move {
+        return Move {
             owner: player_2,
             incoming_fire_coordinate: 0u64,
             player_1: self.caller,

--- a/battleship/src/main.leo
+++ b/battleship/src/main.leo
@@ -16,7 +16,7 @@ program battleship.aleo {
         destroyer: u64,
         // The address of the opponent.
         player: address,
-    ) -> board.aleo/board_state {
+    ) -> board.aleo/BoardState {
         // Verify that each individual ship placement bitstring is valid.
         let valid_carrier: bool = verify.aleo/validate_ship(carrier, 5u64, 31u64, 4311810305u64);
         assert(valid_carrier);
@@ -34,7 +34,7 @@ program battleship.aleo {
         let board: u64 = verify.aleo/create_board(carrier, battleship, cruiser, destroyer);
 
         // Initialize the board state record.
-        let state: board.aleo/board_state = board.aleo/new_board_state(board, player);
+        let state: board.aleo/BoardState = board.aleo/new_board_state(board, player);
 
         return state;
     }
@@ -44,10 +44,10 @@ program battleship.aleo {
     // This function commits a given board to a game with an opponent and creates the initial dummy move.
     transition offer_battleship(
         // The board record to start a game with.
-        board: board.aleo/board_state,
-    ) -> (board.aleo/board_state, move.aleo/move) {
-        let state: board.aleo/board_state = board.aleo/start_board(board);
-        let dummy: move.aleo/move = move.aleo/start_game(board.player_2);
+        board: board.aleo/BoardState,
+    ) -> (board.aleo/BoardState, move.aleo/Move) {
+        let state: board.aleo/BoardState = board.aleo/start_board(board);
+        let dummy: move.aleo/Move = move.aleo/start_game(board.player_2);
 
         return (state, dummy);
     }
@@ -56,16 +56,16 @@ program battleship.aleo {
     // Returns dummy move record owned by the opponent.
     transition start_battleship(
         // The board record to play the game with.
-        board: board.aleo/board_state,
+        board: board.aleo/BoardState,
         // The move record to play to begin the game. This should be the dummy move record created from offer_battleship.
-        move_start: move.aleo/move,
-    ) -> (board.aleo/board_state, move.aleo/move) {
+        move_start: move.aleo/Move,
+    ) -> (board.aleo/BoardState, move.aleo/Move) {
         // Validate that the move players and board players match each other.
         assert_eq(board.player_1, move_start.player_2);
         assert_eq(board.player_2, move_start.player_1);
 
-        let state: board.aleo/board_state = board.aleo/start_board(board);
-        let dummy: move.aleo/move = move.aleo/start_game(board.player_2);
+        let state: board.aleo/BoardState = board.aleo/start_board(board);
+        let dummy: move.aleo/Move = move.aleo/start_game(board.player_2);
 
         return (state, dummy);
     }
@@ -74,12 +74,12 @@ program battleship.aleo {
     // Returns new move record owned by opponent.
     transition play(
         // The board record to update.
-        board: board.aleo/board_state,
+        board: board.aleo/BoardState,
         // The incoming move from the opponent.
-        move_incoming: move.aleo/move,
+        move_incoming: move.aleo/Move,
         // The u64 equivalent of the bitwise representation of the next coordinate to play on the opponent's board.
         shoot: u64,
-    ) -> (board.aleo/board_state, move.aleo/move) {
+    ) -> (board.aleo/BoardState, move.aleo/Move) {
         // Verify the board has been started. This prevents players from starting a game and then creating
         // a brand new board to play with.
         assert(board.game_started);
@@ -89,15 +89,15 @@ program battleship.aleo {
         assert_eq(board.player_2, move_incoming.player_1);
 
         // Play coordinate on own board. Will fail if not a valid move.
-        let hit_or_miss: board.aleo/board_state = board.aleo/update_played_tiles(board, shoot);
+        let hit_or_miss: board.aleo/BoardState = board.aleo/update_played_tiles(board, shoot);
 
         // Update own board with result of last shot.
-        let next_board: board.aleo/board_state = board.aleo/update_hits_and_misses(hit_or_miss, move_incoming.prev_hit_or_miss);
+        let next_board: board.aleo/BoardState = board.aleo/update_hits_and_misses(hit_or_miss, move_incoming.prev_hit_or_miss);
 
         // Assess whether incoming fire coordinate is a hit.
         let is_hit: u64 = move_incoming.incoming_fire_coordinate & board.ships;
 
-        let next_move: move.aleo/move = move.aleo/create_move(move_incoming, shoot, is_hit);
+        let next_move: move.aleo/Move = move.aleo/create_move(move_incoming, shoot, is_hit);
 
         return (next_board, next_move);
     }

--- a/token/src/main.leo
+++ b/token/src/main.leo
@@ -3,7 +3,7 @@ program token.aleo {
     // and `u64` as the value.
     mapping account: address => u64;
 
-    record token {
+    record Token {
         // The token owner.
         owner: address,
         // The token amount.
@@ -27,8 +27,8 @@ program token.aleo {
     }
 
     // The function `mint_private` initializes a new record with the specified amount of tokens for the receiver.
-    transition mint_private(receiver: address, amount: u64) -> token {
-        return token {
+    transition mint_private(receiver: address, amount: u64) -> Token {
+        return Token {
             owner: receiver,
             amount: amount,
         };
@@ -54,20 +54,20 @@ program token.aleo {
     }
 
     // The function `transfer_private` sends the specified token amount to the token receiver from the specified token record.
-    transition transfer_private(sender: token, receiver: address, amount: u64) -> (token, token) {
+    transition transfer_private(sender: Token, receiver: address, amount: u64) -> (Token, Token) {
         // Checks the given token record has sufficient balance.
         // This `sub` operation is safe, and the proof will fail if an overflow occurs.
         // `difference` holds the change amount to be returned to sender.
         let difference: u64 = sender.amount - amount;
 
         // Produce a token record with the change amount for the sender.
-        let remaining: token = token {
+        let remaining: Token = Token {
             owner: sender.owner,
             amount: difference,
         };
 
         // Produce a token record for the specified receiver.
-        let transferred: token = token {
+        let transferred: Token = Token {
             owner: receiver,
             amount: amount,
         };
@@ -78,14 +78,14 @@ program token.aleo {
 
     // The function `transfer_private_to_public` turns a specified token amount from a token record into public tokens for the specified receiver.
     // This function preserves privacy for the sender's record, however it publicly reveals the token receiver and the token amount.
-    async transition transfer_private_to_public(sender: token, public receiver: address, public amount: u64) -> (token, Future) {
+    async transition transfer_private_to_public(sender: Token, public receiver: address, public amount: u64) -> (Token, Future) {
         // Checks the given token record has a sufficient token amount.
         // This `sub` operation is safe, and the proof will fail if an underflow occurs.
         // `difference` holds the change amount for the caller.
         let difference: u64 = sender.amount - amount;
 
         // Produces a token record with the change amount for the caller.
-        let remaining: token = token {
+        let remaining: Token = Token {
             owner: sender.owner,
             amount: difference,
         };
@@ -105,9 +105,9 @@ program token.aleo {
 
     // The function `transfer_public_to_private` turns a specified token amount from `account` into a token record for the specified receiver.
     // This function preserves privacy for the receiver's record, however it publicly reveals the caller and the specified token amount.
-    async transition transfer_public_to_private(public receiver: address, public amount: u64) -> (token, Future) {
+    async transition transfer_public_to_private(public receiver: address, public amount: u64) -> (Token, Future) {
         // Produces a token record for the token receiver.
-        let transferred: token = token {
+        let transferred: Token = Token {
             owner: receiver,
             amount: amount,
         };


### PR DESCRIPTION
This PR modifies three examples to use CamelCase  naming convention for Records.