### PR TITLE
Fix error in comments for bash scripts

### DIFF
--- a/auction/run.sh
+++ b/auction/run.sh
@@ -7,18 +7,18 @@ then
 fi
 
 # The private key and address of the first bidder.
-# Swap these into program.json, when running transactions as the first bidder.
+# Swap these into .env, when running transactions as the first bidder.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
 
 # The private key and address of the second bidder.
-# Swap these into program.json, when running transactions as the second bidder.
+# Swap these into .env, when running transactions as the second bidder.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
 
 
 # The private key and address of the auctioneer.
-# Swap these into program.json, when running transactions as the auctioneer.
+# Swap these into .env, when running transactions as the auctioneer.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp2GUmKbVsuc1NSj28pa1WTQuZaK5f1DQJAT6vPcHyWokG
 

--- a/basic_bank/run.sh
+++ b/basic_bank/run.sh
@@ -7,12 +7,12 @@ then
 fi
 
 # The private key and address of the bank.
-# Swap these into program.json, when running transactions as the bank.
+# Swap these into .env, when running transactions as the bank.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
 
 # The private key and address of the user.
-# Swap these into program.json, when running transactions as the user.
+# Swap these into .env, when running transactions as the user.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
 

--- a/token/run.sh
+++ b/token/run.sh
@@ -7,12 +7,12 @@ then
 fi
 
 # The private key and address of Alice.
-# Swap these into program.json, when running transactions as the first bidder.
+# Swap these into .env, when running transactions as the first bidder.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
 
 # The private key and address of Bob.
-# Swap these into program.json, when running transactions as the second bidder.
+# Swap these into .env, when running transactions as the second bidder.
 # NETWORK=testnet
 # PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
 


### PR DESCRIPTION
This PR fixes a typo in the comments for the bash script for three of the examples. 

```
# The private key and address of the user.
# Swap these into program.json, when running transactions as the user.
# NETWORK=testnet
# PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
```

The second line should specify the `.env` file, NOT the `program.json` file.