### PR TITLE
Fixed indentations for test code

### DIFF
--- a/example_with_test/tests/test_example_program.leo
+++ b/example_with_test/tests/test_example_program.leo
@@ -18,18 +18,18 @@ program test_example_program.aleo {
     // `script` testing mode.
     @test
     script test_async() {
-    const VAL: field = 12field;
-    let fut: Future = example_program.aleo/set_mapping(VAL);
-    // We must await this future for the async code to run.
-    fut.await();
-    assert_eq(Mapping::get(example_program.aleo/map, 0field), VAL);
+        const VAL: field = 12field;
+        let fut: Future = example_program.aleo/set_mapping(VAL);
+        // We must await this future for the async code to run.
+        fut.await();
+        assert_eq(Mapping::get(example_program.aleo/map, 0field), VAL);
 
-    // scripts can also do other things normally only async code can do:
-    let rand_val: field = ChaCha::rand_field();
-    Mapping::set(example_program.aleo/map, VAL, rand_val);
-    let value: field = Mapping::get(example_program.aleo/map, VAL);
-    assert_eq(value, rand_val);
-}
+        // scripts can also do other things normally only async code can do:
+        let rand_val: field = ChaCha::rand_field();
+        Mapping::set(example_program.aleo/map, VAL, rand_val);
+        let value: field = Mapping::get(example_program.aleo/map, VAL);
+        assert_eq(value, rand_val);
+    }
 
     @test
     transition test_record_maker() {


### PR DESCRIPTION
This PR fixes the indentations for the script test in the test file for the `example_with_test` example.