### PR TITLE
update to 4.0.1

### DIFF
--- a/auction/build/program.json
+++ b/auction/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/auction/program.json
+++ b/auction/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/basic_bank/build/program.json
+++ b/basic_bank/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/basic_bank/program.json
+++ b/basic_bank/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/battleship/board/program.json
+++ b/battleship/board/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/battleship/build/program.json
+++ b/battleship/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/battleship/move/program.json
+++ b/battleship/move/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/battleship/program.json
+++ b/battleship/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies" : [
       {
           "name": "board.aleo",

--- a/battleship/verify/program.json
+++ b/battleship/verify/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/bubblesort/build/program.json
+++ b/bubblesort/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/bubblesort/program.json
+++ b/bubblesort/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/core/build/program.json
+++ b/core/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/core/program.json
+++ b/core/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/example_with_test/build/program.json
+++ b/example_with_test/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/example_with_test/program.json
+++ b/example_with_test/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/fibonacci/build/program.json
+++ b/fibonacci/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/fibonacci/program.json
+++ b/fibonacci/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/groups/build/program.json
+++ b/groups/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/groups/program.json
+++ b/groups/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzdebruijn/build/program.json
+++ b/hackers-delight/ntzdebruijn/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzdebruijn/program.json
+++ b/hackers-delight/ntzdebruijn/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzgaudet/build/program.json
+++ b/hackers-delight/ntzgaudet/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzgaudet/program.json
+++ b/hackers-delight/ntzgaudet/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzloops/build/program.json
+++ b/hackers-delight/ntzloops/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzloops/program.json
+++ b/hackers-delight/ntzloops/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzmasks/build/program.json
+++ b/hackers-delight/ntzmasks/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzmasks/program.json
+++ b/hackers-delight/ntzmasks/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzreisers/build/program.json
+++ b/hackers-delight/ntzreisers/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzreisers/program.json
+++ b/hackers-delight/ntzreisers/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzseals/build/program.json
+++ b/hackers-delight/ntzseals/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzseals/program.json
+++ b/hackers-delight/ntzseals/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzsearchtree/build/program.json
+++ b/hackers-delight/ntzsearchtree/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzsearchtree/program.json
+++ b/hackers-delight/ntzsearchtree/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzsmallvals/build/program.json
+++ b/hackers-delight/ntzsmallvals/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/hackers-delight/ntzsmallvals/program.json
+++ b/hackers-delight/ntzsmallvals/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/helloworld/build/program.json
+++ b/helloworld/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/helloworld/hello/build/program.json
+++ b/helloworld/hello/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/helloworld/hello/program.json
+++ b/helloworld/hello/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/helloworld/program.json
+++ b/helloworld/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/interest/build/program.json
+++ b/interest/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/interest/program.json
+++ b/interest/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/lottery/build/program.json
+++ b/lottery/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/lottery/program.json
+++ b/lottery/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/message/build/program.json
+++ b/message/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/message/program.json
+++ b/message/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/simple_token/build/program.json
+++ b/simple_token/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/simple_token/program.json
+++ b/simple_token/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tictactoe/build/program.json
+++ b/tictactoe/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tictactoe/program.json
+++ b/tictactoe/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/token/build/program.json
+++ b/token/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/token/program.json
+++ b/token/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/twoadicity/build/program.json
+++ b/twoadicity/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/twoadicity/program.json
+++ b/twoadicity/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/admin/build/program.json
+++ b/upgrades/admin/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/admin/program.json
+++ b/upgrades/admin/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/noupgrade/build/program.json
+++ b/upgrades/noupgrade/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/noupgrade/program.json
+++ b/upgrades/noupgrade/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/timelock/build/program.json
+++ b/upgrades/timelock/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/timelock/program.json
+++ b/upgrades/timelock/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/vote/basic_voting/program.json
+++ b/upgrades/vote/basic_voting/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/vote/build/program.json
+++ b/upgrades/vote/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/upgrades/vote/program.json
+++ b/upgrades/vote/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": [
     {
       "name": "basic_voting.aleo",

--- a/vote/build/program.json
+++ b/vote/build/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/vote/program.json
+++ b/vote/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.0.0",
+  "leo": "4.0.1",
   "dependencies": null,
   "dev_dependencies": null
 }


### PR DESCRIPTION
## Summary
- Bumps the `leo` version field in all `program.json` files from `4.0.0` to `4.0.1`
- Rebuilds all 30 projects to regenerate `build/` directories using the 4.0.1 binary

## Test plan
- [x] All 30 projects built successfully with `leo 4.0.1` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)